### PR TITLE
add: constraint to check invitation authority

### DIFF
--- a/programs/wordcel/src/instructions.rs
+++ b/programs/wordcel/src/instructions.rs
@@ -23,7 +23,9 @@ pub struct Initialize<'info> {
             user.key().as_ref()
         ],
         seeds::program = invitation_program.key(),
-        bump = invitation.bump
+        //FIXME: This would allow someone to externally initialize an invite account and use it in their posts. The attack surface because of this bug is limited because of the user key check, however since we read the bump from the program, the user can create multiple invite accounts with different bumps.
+        bump = invitation.bump,
+        constraint = invitation.authority == user.key()
     )]
     pub invitation: Account<'info, Invite>,
     #[account(mut)]


### PR DESCRIPTION
Proposed changes adds an additional constraint to check if the invitation is actually owned by the user. My suspicion is that the current program will let anyone with a valid create a profile.
