### PR TITLE
Claim invite

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "idl:upgrade:wordcel:mainnet": "anchor idl upgrade -f target/idl/wordcel.json --provider.cluster mainnet --provider.wallet ~/.config/solana/wordcel_mainnet.json EXzAYHZ8xS6QJ6xGRsdKZXixoQBLsuMbmwJozm85jHp",
     "idl:upgrade:invite:mainnet": "anchor idl upgrade -f target/idl/invite.json --provider.cluster mainnet --provider.wallet ~/.config/solana/wordcel_mainnet.json Fc4q6ttyDHr11HjMHRvanG9SskeR24Q62egdwsUUMHLf",
     "idl:upgrade:wordcel:devnet": "anchor idl upgrade -f target/idl/wordcel.json --provider.cluster devnet --provider.wallet ~/.config/solana/wordcel_admin.json D9JJgeRf2rKq5LNMHLBMb92g4ZpeMgCyvZkd7QKwSCzg",
-    "idl:upgrade:invite:devnet": "anchor idl upgrade -f target/idl/invite.json --provider.cluster devnet --provider.wallet ~/.config/solana/wordcel_admin.json 6G5x4Es2YZYB5e4QkFJN88TrfLABkYEQpkUH5Gob9Cut"
+    "idl:upgrade:invite:devnet": "anchor idl upgrade -f target/idl/invite.json --provider.cluster devnet --provider.wallet ~/.config/solana/wordcel_admin.json 6G5x4Es2YZYB5e4QkFJN88TrfLABkYEQpkUH5Gob9Cut",
+    "anchor:publish:invite:mainnet": "anchor publish invite --provider.cluster mainnet --provider.wallet ~/.config/solana/wordcel_mainnet.json -- --features mainnet"
   },
   "dependencies": {
     "@bundlr-network/client": "^0.5.12",

--- a/tests/invite.spec.ts
+++ b/tests/invite.spec.ts
@@ -1,137 +1,195 @@
-import * as anchor from '@project-serum/anchor';
-import {Program, AnchorError} from '@project-serum/anchor';
-import {Invite} from '../target/types/invite';
-import {expect} from 'chai';
-import {PublicKey} from '@solana/web3.js';
-import {getInviteAccount, sendInvite} from "./utils/invite";
-import {airdrop} from './utils';
+import * as anchor from "@project-serum/anchor";
+import { Program, AnchorError } from "@project-serum/anchor";
+import { Invite } from "../target/types/invite";
+import { expect } from "chai";
+import { PublicKey } from "@solana/web3.js";
+import { getInviteAccount, sendInvite } from "./utils/invite";
+import { airdrop } from "./utils";
 
-const {SystemProgram} = anchor.web3;
+const { SystemProgram } = anchor.web3;
 const provider = anchor.getProvider();
 
 const program = anchor.workspace.Invite as Program<Invite>;
 const user = provider.wallet.publicKey;
 
+describe("Invitation", async () => {
+  // Prepare test user.
+  const testUser = anchor.web3.Keypair.generate();
+  let oneInviteAccount: PublicKey;
 
-describe('Invitation', async () => {
-    // Prepare test user.
-    const testUser = anchor.web3.Keypair.generate();
-    let oneInviteAccount: PublicKey;
+  before(async () => {
+    await airdrop(testUser.publicKey);
+    oneInviteAccount = await getInviteAccount(testUser.publicKey);
+  });
 
-    before(async () => {
-        await airdrop(testUser.publicKey);
-        oneInviteAccount = await getInviteAccount(testUser.publicKey);
-    });
+  it("should initialize", async () => {
+    await program.methods
+      .initialize()
+      .accounts({
+        inviteAccount: oneInviteAccount,
+        authority: testUser.publicKey,
+        payer: user,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+    const data = await program.account.invite.fetch(oneInviteAccount);
+    expect(data.authority.toString()).to.equal(testUser.publicKey.toString());
+  });
 
+  it("should send invite to others", async () => {
+    const randomUser = anchor.web3.Keypair.generate();
+    const [inviter, invited] = await sendInvite(
+      testUser,
+      randomUser.publicKey,
+      user
+    );
+    const data = await program.account.invite.fetch(inviter);
+    expect(data.invitesLeft).to.equal(1);
+    expect(data.invitesSent).to.equal(1);
+    const toInviteData = await program.account.invite.fetch(invited);
+    expect(toInviteData.invitedBy.toString()).to.equal(
+      testUser.publicKey.toString()
+    );
+    expect(toInviteData.authority.toString()).to.equal(
+      randomUser.publicKey.toString()
+    );
+  });
 
-    it("should initialize", async () => {
+  it("should allow a user to claim more invites", async () => {
+    // Set up new user
+    const newUser = anchor.web3.Keypair.generate();
+    await airdrop(newUser.publicKey);
+    const inviteAccount = await getInviteAccount(newUser.publicKey);
+    await program.methods
+      .initialize()
+      .accounts({
+        inviteAccount: inviteAccount,
+        authority: newUser.publicKey,
+        payer: user,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
 
-        await program.methods.initialize()
-            .accounts({
-                inviteAccount: oneInviteAccount,
-                authority: testUser.publicKey,
-                payer: user,
-                systemProgram: SystemProgram.programId
-            })
-            .rpc();
-        const data = await program.account.invite.fetch(oneInviteAccount);
-        expect(data.authority.toString()).to.equal(testUser.publicKey.toString());
-    });
+    //First Invite
+    const randomUser = anchor.web3.Keypair.generate();
+    await sendInvite(newUser, randomUser.publicKey, user);
 
-    it("should send invite to others", async () => {
-        const randomUser = anchor.web3.Keypair.generate();
-        const [inviter, invited] = await sendInvite(testUser, randomUser.publicKey, user)
-        const data = await program.account.invite.fetch(inviter);
-        expect(data.invitesLeft).to.equal(1);
-        expect(data.invitesSent).to.equal(1);
-        const toInviteData = await program.account.invite.fetch(invited);
-        expect(toInviteData.invitedBy.toString()).to.equal(testUser.publicKey.toString());
-        expect(toInviteData.authority.toString()).to.equal(randomUser.publicKey.toString());
-    });
+    //Second Invite
+    const randomUser1 = anchor.web3.Keypair.generate();
+    await sendInvite(newUser, randomUser1.publicKey, user);
 
-    it("should not be able to send more than 2 invites", async () => {
-        // Set up new user
-        const newUser = anchor.web3.Keypair.generate();
-        await airdrop(newUser.publicKey);
-        const inviteAccount = await getInviteAccount(newUser.publicKey);
-        await program.methods.initialize()
-            .accounts({
-                inviteAccount: inviteAccount,
-                authority: newUser.publicKey,
-                payer: user,
-                systemProgram: SystemProgram.programId
-            })
-            .rpc();
+    await program.methods
+      .claimInvite()
+      .accounts({
+        inviteAccount: inviteAccount,
+        authority: newUser.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([newUser])
+      .rpc();
+    const invite_data = await program.account.invite.fetch(inviteAccount);
+    expect(invite_data.invitesLeft).to.equal(4);
+  });
 
-        //First Invite
-        const randomUser = anchor.web3.Keypair.generate();
-        await sendInvite(newUser, randomUser.publicKey, user);
+  it("should not be able to send more than 2 invites", async () => {
+    // Set up new user
+    const newUser = anchor.web3.Keypair.generate();
+    await airdrop(newUser.publicKey);
+    const inviteAccount = await getInviteAccount(newUser.publicKey);
+    await program.methods
+      .initialize()
+      .accounts({
+        inviteAccount: inviteAccount,
+        authority: newUser.publicKey,
+        payer: user,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
 
-        //Second Invite
-        const randomUser1 = anchor.web3.Keypair.generate();
-        await sendInvite(newUser, randomUser1.publicKey, user);
+    //First Invite
+    const randomUser = anchor.web3.Keypair.generate();
+    await sendInvite(newUser, randomUser.publicKey, user);
 
-        // Third Invite
-        const randomUser2 = anchor.web3.Keypair.generate();
-        try {
-            await sendInvite(newUser, randomUser2.publicKey, user);
-        } catch (error) {
-            const anchorError = AnchorError.parse(error.logs);
-            expect(anchorError.error.errorCode.code).to.equal('NoInvitesLeft');
-        }
-    });
+    //Second Invite
+    const randomUser1 = anchor.web3.Keypair.generate();
+    await sendInvite(newUser, randomUser1.publicKey, user);
 
+    // Third Invite
+    const randomUser2 = anchor.web3.Keypair.generate();
+    try {
+      await sendInvite(newUser, randomUser2.publicKey, user);
+    } catch (error) {
+      const anchorError = AnchorError.parse(error.logs);
+      expect(anchorError.error.errorCode.code).to.equal("NoInvitesLeft");
+    }
+  });
 
-    it("should not allow random user to initialize", async () => {
-        const randomUser = anchor.web3.Keypair.generate();
-        const seed = [Buffer.from("invite"), randomUser.publicKey.toBuffer()];
-        const [account, _] = await anchor.web3.PublicKey.findProgramAddress(seed, program.programId);
-        const tx = await program.methods.initialize()
-            .accounts({
-                inviteAccount: account,
-                authority: randomUser.publicKey,
-                payer: testUser.publicKey,
-                systemProgram: SystemProgram.programId
-            })
-            .transaction();
-        tx.feePayer = user;
-        tx.recentBlockhash = (await provider.connection.getRecentBlockhash()).blockhash;
-        tx.sign(testUser);
-        try {
-            await provider.sendAndConfirm(tx)
-        } catch (error) {
-            const anchorError = AnchorError.parse(error.logs);
-            expect(anchorError.error.errorCode.code).to.equal('UnAuthorizedInitialization');
-        }
-    });
+  it("should not allow random user to initialize", async () => {
+    const randomUser = anchor.web3.Keypair.generate();
+    const seed = [Buffer.from("invite"), randomUser.publicKey.toBuffer()];
+    const [account, _] = await anchor.web3.PublicKey.findProgramAddress(
+      seed,
+      program.programId
+    );
+    const tx = await program.methods
+      .initialize()
+      .accounts({
+        inviteAccount: account,
+        authority: randomUser.publicKey,
+        payer: testUser.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .transaction();
+    tx.feePayer = user;
+    tx.recentBlockhash = (
+      await provider.connection.getRecentBlockhash()
+    ).blockhash;
+    tx.sign(testUser);
+    try {
+      await provider.sendAndConfirm(tx);
+    } catch (error) {
+      const anchorError = AnchorError.parse(error.logs);
+      expect(anchorError.error.errorCode.code).to.equal(
+        "UnAuthorizedInitialization"
+      );
+    }
+  });
 
-    it("should allow admin to initialize as many accounts as required", async () => {
-        for (let index = 0; index < 5; index++) {
-            const randomUser = anchor.web3.Keypair.generate();
-            const seed = [Buffer.from("invite"), randomUser.publicKey.toBuffer()];
-            const [account, _] = await anchor.web3.PublicKey.findProgramAddress(seed, program.programId);
-            await program.methods.initialize()
-                .accounts({
-                    inviteAccount: account,
-                    authority: randomUser.publicKey,
-                    payer: user,
-                    systemProgram: SystemProgram.programId
-                })
-                .rpc();
-            const data = await program.account.invite.fetch(account);
-            expect(data.authority.toString()).to.equal(randomUser.publicKey.toString());
-        }
-    });
+  it("should allow admin to initialize as many accounts as required", async () => {
+    for (let index = 0; index < 5; index++) {
+      const randomUser = anchor.web3.Keypair.generate();
+      const seed = [Buffer.from("invite"), randomUser.publicKey.toBuffer()];
+      const [account, _] = await anchor.web3.PublicKey.findProgramAddress(
+        seed,
+        program.programId
+      );
+      await program.methods
+        .initialize()
+        .accounts({
+          inviteAccount: account,
+          authority: randomUser.publicKey,
+          payer: user,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+      const data = await program.account.invite.fetch(account);
+      expect(data.authority.toString()).to.equal(
+        randomUser.publicKey.toString()
+      );
+    }
+  });
 
-    it("should not allow uninitialized invite account to send an invite", async () => {
-        const randomUser = anchor.web3.Keypair.generate();
-        const randomUser1 = anchor.web3.Keypair.generate();
-        await airdrop(randomUser1.publicKey);
-        try {
-            await sendInvite(randomUser, randomUser1.publicKey, user)
-        } catch (error) {
-            const anchorError = AnchorError.parse(error.logs);
-            expect(anchorError.error.errorCode.code).to.equal('AccountNotInitialized');
-        }
-    });
+  it("should not allow uninitialized invite account to send an invite", async () => {
+    const randomUser = anchor.web3.Keypair.generate();
+    const randomUser1 = anchor.web3.Keypair.generate();
+    await airdrop(randomUser1.publicKey);
+    try {
+      await sendInvite(randomUser, randomUser1.publicKey, user);
+    } catch (error) {
+      const anchorError = AnchorError.parse(error.logs);
+      expect(anchorError.error.errorCode.code).to.equal(
+        "AccountNotInitialized"
+      );
+    }
+  });
 });


### PR DESCRIPTION
This change would allow users to claim more invites as they use up the old one. Can be merged and deployed after enable users to send invites to others in the front end and users have started asking for more invites to give.